### PR TITLE
13.1.hardcode hyperlink to bookshop website

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:3030'
-  }
+    baseUrl: 'http://localhost:3030',
+    chromeWebSecurity: false
+  },
 })

--- a/cypress/e2e/bookshop_details_spec.cy.js
+++ b/cypress/e2e/bookshop_details_spec.cy.js
@@ -18,9 +18,13 @@ describe('The bookshop information', () => {
     cy.get('.bookshop-address').last().should('contain', 'SW9 8PS')
   })
 
-  it('contains a link to the bookshop website', () => {
+  it('contains links to the bookshop websites', () => {
     cy.visit('/openbook')
     cy.get('.website-link').first().click()
     cy.url().should('be.equal', 'https://www.gaystheword.co.uk/')
+
+    cy.visit('/openbook')
+    cy.get('.website-link').last().click()
+    cy.url().should('be.equal', 'https://www.roundtablebooks.co.uk/')
   })
 })

--- a/cypress/e2e/bookshop_details_spec.cy.js
+++ b/cypress/e2e/bookshop_details_spec.cy.js
@@ -17,4 +17,10 @@ describe('The bookshop information', () => {
     cy.get('.bookshop-address').last().should('contain', 'London')
     cy.get('.bookshop-address').last().should('contain', 'SW9 8PS')
   })
+
+  it('contains a link to the bookshop website', () => {
+    cy.visit('/openbook')
+    cy.get('.website-link').first().click()
+    cy.url().should('be.equal', 'https://www.gaystheword.co.uk/')
+  })
 })

--- a/cypress/e2e/homepage_spec.cy.js
+++ b/cypress/e2e/homepage_spec.cy.js
@@ -4,3 +4,4 @@ describe('The homepage', () => {
         cy.get('h1').should('contain', 'OpenBook')
     })
   })
+  

--- a/frontend/views/index.jade
+++ b/frontend/views/index.jade
@@ -2,6 +2,7 @@ block content
   h1 OpenBook
   div(class="bookshop-container", id="Gaystheword")
     h3(class='bookshop-name') Gay's the Word
+    a(class='website-link', href="http://gaystheword.co.uk") Visit Website
     p(class='bookshop-address')
       | 66 Marchmont Street 
       br

--- a/frontend/views/index.jade
+++ b/frontend/views/index.jade
@@ -12,6 +12,7 @@ block content
   
   div(class="bookshop-container", id="Roundtablebooks")
     h3(class='bookshop-name') Round Table Books
+    a(class='website-link', href="https://www.roundtablebooks.co.uk/") Visit Website
     p(class='bookshop-address')
       | 97 Granville Arcade
       br


### PR DESCRIPTION
Turned Chrome security off so that cypress can navigate to an external url.
Links added to both bookshop websites, cypress tests included
